### PR TITLE
feat: secure token management with pre-commit hook and documentation

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -178,3 +178,6 @@ source_if_exists "$HOME/.git-prompt.sh"
 # Tell GPG what terminal to use for passphrase prompts
 export GPG_TTY=$(tty)
 
+# source tokens/secrets (not committed to source control)
+source_if_exists "$HOME/.tokens"
+

--- a/gitconfig
+++ b/gitconfig
@@ -9,6 +9,7 @@
     autocrlf = input
     editor = vim
     excludesfile = ~/.gitignore_global
+    hooksPath = ~/.hooks
     ignorecase = true
     longpaths = true
     whitespace = trailing-space,space-before-tab

--- a/gitignore_global
+++ b/gitignore_global
@@ -6,3 +6,13 @@
 .project
 .settings/
 
+# secret files — never commit these
+.tokens
+.env
+.env.local
+.env.secret
+.env.production
+.secrets
+.netrc
+.nexus
+

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Blocks commits that stage files commonly used to store secrets.
+
+PROTECTED=(
+    .tokens
+    .env
+    .env.local
+    .env.secret
+    .env.production
+    .secrets
+    .netrc
+    .nexus
+)
+
+staged=$(git diff --cached --name-only)
+
+for f in "${PROTECTED[@]}"; do
+    if echo "$staged" | grep -qE "(^|/)${f}$"; then
+        echo "ERROR: Refusing to commit '$f' — this file may contain secrets."
+        echo "Remove it from the index with: git reset HEAD '$f'"
+        exit 1
+    fi
+done

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,10 @@ git clone git@github.com:clormor/dotfiles.git && cd dotfiles
 ./setup.sh
 ```
 
+`setup.sh` does the following:
+1. Symlinks every file in this repo into `$HOME` as a dotfile (e.g. `bashrc` → `~/.bashrc`). Any existing file is first backed up as `.orig`.
+2. Symlinks `hooks/` to `~/.hooks` and marks all hook scripts executable.
+
 ## Files
 
 | File | Symlinked to |
@@ -21,7 +25,51 @@ git clone git@github.com:clormor/dotfiles.git && cd dotfiles
 | `gitconfig-osx` | `~/.gitconfig-osx` |
 | `gitconfig-work` | `~/.gitconfig-work` |
 | `gitignore_global` | `~/.gitignore_global` |
+| `hooks/` | `~/.hooks/` |
 | `mkshrc` | `~/.mkshrc` |
 | `vimrc` | `~/.vimrc` |
 | `zprofile` | `~/.zprofile` |
 | `zshrc` | `~/.zshrc` |
+
+## Managing tokens and secrets
+
+Secrets (API keys, tokens, passwords) should never be committed to source control. This repo provides three layers of protection.
+
+### Layer 1 — `~/.tokens`
+
+Store exported environment variables in `~/.tokens`:
+
+```bash
+export GITHUB_TOKEN=ghp_...
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+`bashrc` automatically sources this file on every shell start via:
+
+```bash
+source_if_exists "$HOME/.tokens"
+```
+
+`~/.tokens` is listed in `gitignore_global` so it can never be accidentally staged.
+
+### Layer 2 — global gitignore
+
+`gitignore_global` (symlinked to `~/.gitignore_global` and referenced by `gitconfig`) prevents the following filenames from being staged in **any** repo on your machine:
+
+```
+.tokens  .env  .env.local  .env.secret  .env.production  .secrets  .netrc  .nexus
+```
+
+### Layer 3 — global pre-commit hook
+
+`hooks/pre-commit` (symlinked to `~/.hooks/pre-commit`) runs before every commit across all repos. It refuses the commit if any of the protected filenames above are staged, printing a clear error and the command to unstage the file.
+
+`gitconfig` tells git to use `~/.hooks` as the global hooks directory:
+
+```ini
+[core]
+    hooksPath = ~/.hooks
+```
+
+No manual install step is needed — `setup.sh` handles everything.

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,12 @@
+#!/usr/bin/env bash
+# setup.sh — symlinks dotfiles into your home directory.
+#
+# What this script does:
+#   1. Symlinks each file in this repo into $HOME as a hidden file
+#      (e.g. bashrc -> ~/.bashrc). Existing files are backed up as .orig.
+#   2. Symlinks the hooks/ directory to ~/.hooks and makes all hook
+#      scripts executable so that git picks them up globally.
+
 SCRIPT_NAME=$(basename $0)
 DOTFILES=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 echo "Installing dotfiles from $DOTFILES"
@@ -15,3 +24,7 @@ for FILE in `ls $DOTFILES`; do
     ln -sf "$SOURCE" "$DEST"
 done
 
+# make all hook scripts executable
+if [ -d "$HOME/.hooks" ]; then
+    chmod +x "$HOME/.hooks/"*
+fi


### PR DESCRIPTION
Implements layered token security as described in issue #4:

- `~/.tokens` sourced automatically in every shell via bashrc
- Global gitignore blocks common secret filenames across all repos
- Global pre-commit hook prevents accidental staging of secret files
- `setup.sh` documents itself and ensures hooks are executable
- README documents all three protection layers

No manual install step needed: `setup.sh` handles everything.

Closes #4

Generated with [Claude Code](https://claude.ai/code)