### PR TITLE
feat: add gitconfig overrides for valliance-foundry repos

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,6 +30,10 @@ Files at the repo root are stored without the leading dot. `setup.sh` prepends i
 - `~/.gitconfig-work` applies for repos under `work/` or the Coder remote path.
 - GPG commit signing (`gpgsign = true`) is enabled via `gitconfig-gpg` on macOS. The signing key is defined in `gitconfig-osx`.
 
+## Gotchas
+
+- **includeIf ordering**: Git uses the last value for a key. Any `includeIf` directive that overrides a default (e.g. `user.email`) must appear *after* the section containing that default in `gitconfig`. Placing it before means the default wins.
+
 ## GitHub Actions
 
 Two workflows run on PRs:

--- a/.claude/notes/global.md
+++ b/.claude/notes/global.md
@@ -1,0 +1,8 @@
+# Project Learnings
+
+### [2026-05-19] Git includeIf directive ordering
+
+**Context**: Adding a gitconfig-foundry file with an email override, wired up via includeIf.
+**Correction**: The includeIf was placed at the top of gitconfig, before the [user] block. The foundry email was not taking effect because git uses the last value for a key, so the default [user] email overrode it.
+**Rule**: Any includeIf directive that overrides a default value must appear after the section containing that default in the file.
+**Applies to**: gitconfig / any git config layering work

--- a/gitconfig
+++ b/gitconfig
@@ -44,3 +44,5 @@
 	tool = vscode
 [mergetool "vscode"]
 	cmd = code --wait $MERGED
+[includeIf "gitdir:**/valliance-foundry/**"]
+    path = ~/.gitconfig-foundry

--- a/gitconfig-foundry
+++ b/gitconfig-foundry
@@ -1,0 +1,5 @@
+[user]
+    # Foundry user ID for the Valliance Foundry instance
+    email = 265e0633-7ffc-44c5-81d0-abd203d24e9f
+[commit]
+    gpgsign = false


### PR DESCRIPTION
## Summary

- Adds `gitconfig-foundry` with a Foundry-specific author email (the Foundry user UUID) and GPG signing disabled
- Wires it in via `includeIf "gitdir:**/valliance-foundry/**"` placed at the end of `gitconfig` so it overrides the defaults
- Adds a Gotchas entry to `.claude/CLAUDE.md` capturing the `includeIf` ordering rule

## Test Plan

- [ ] Run `./setup.sh` to symlink `gitconfig-foundry` into `$HOME`
- [ ] In a repo under `valliance-foundry/`, run `git config user.email` and confirm it returns the Foundry UUID
- [ ] Run `git config commit.gpgsign` and confirm it returns `false`
- [ ] In a repo outside `valliance-foundry/`, confirm the default email and GPG signing are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)