### PR TITLE
chore: add account settings URL to Foundry gitconfig

### DIFF
--- a/gitconfig-valliance-foundry
+++ b/gitconfig-valliance-foundry
@@ -1,5 +1,6 @@
 [user]
     # Foundry user ID for the Valliance Foundry instance
+    # https://valliance.palantirfoundry.com/workspace/settings/account
     email = 265e0633-7ffc-44c5-81d0-abd203d24e9f
 [commit]
     gpgsign = false


### PR DESCRIPTION
## Summary

- Adds a URL comment pointing to the Valliance Foundry account settings page
- Makes the Foundry user ID discoverable without hunting through the UI
- No functional change to git behaviour

## Test plan

- [ ] Confirm `~/.gitconfig-valliance-foundry` symlink is updated after running `setup.sh`
- [ ] Verify git operations on Foundry-path repos are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)